### PR TITLE
Update lib.py

### DIFF
--- a/utils/lib.py
+++ b/utils/lib.py
@@ -1179,7 +1179,7 @@ class Augmenter(object):
             len0 = len(data) # record original length
             
             # PlaySpeed
-            data = librosa.effects.time_stretch(data, rate)
+            data = librosa.effects.time_stretch(data, rate=rate)
             
             # Pad
             if self.keep_size:


### PR DESCRIPTION
Change call to librosa.effects.time_stretch() to reflect new syntax to specify rate. This change corrects the following error:

![image](https://github.com/ruslanmv/Speech-Recognition-with-RNN-Neural-Networks/assets/20921834/a5123548-d2c3-4ebe-bb55-c1b1c109f80f)

**After correction:**
![image](https://github.com/ruslanmv/Speech-Recognition-with-RNN-Neural-Networks/assets/20921834/86ce1ec7-864c-43c9-bbec-560fe861ddfb)
